### PR TITLE
changed subway cam image alt

### DIFF
--- a/Senior Project/html/subwayCam.html
+++ b/Senior Project/html/subwayCam.html
@@ -27,7 +27,7 @@
 
     </div>
     <h1>Subway cam</h1>
-    <img id="subwayCam" alt="Live Subway Cam Feed" src="http://subway-cam.rose-hulman.edu/stream.jpg">
+    <img id="subwayCam" alt="The Subway Cam is only available on-campus." src="http://subway-cam.rose-hulman.edu/stream.jpg">
     <div id="hours">
         <h4>Hours of Operation:</h4>
         <h4>Mon-Fri: 11:00 AM - 11:00 PM</h4>


### PR DESCRIPTION
turns out, this is sufficient to indicate that the subway cam is only
viewable on the Rose-Hulman network. When trying to access it from any
other network, the image will not display, and instead the alt text will
be shown.